### PR TITLE
Use correct config option for the log path.

### DIFF
--- a/ovos_cli_client/__main__.py
+++ b/ovos_cli_client/__main__.py
@@ -49,12 +49,17 @@ def main():
 
     legacy_path = "/var/log/mycroft"
 
-    if 'logs' not in config:
-        config["logs"] = []
-    if 'path' not in config["logs"]:
-        config["logs"]["path"] = f"{xdg_state_home()}/{get_xdg_base()}"
 
-    log_dir = os.path.expanduser(config["logs"]["path"])
+    log_dir = f"{xdg_state_home()}/{get_xdg_base()}"
+
+    if 'logs' in config and 'path' in config["logs"]:
+        log_dir = config["logs"]["path"]
+    if 'log_dir' in config:
+        LOG.warning("The variable 'log_dir' in the cli config is deprecated. Please use 'logs.path'.")
+        log_dir = config["log_dir"]
+
+
+    log_dir = os.path.expanduser(log_dir)
     for f in os.listdir(log_dir):
         if not f.endswith(".log"):
             continue

--- a/ovos_cli_client/__main__.py
+++ b/ovos_cli_client/__main__.py
@@ -49,10 +49,12 @@ def main():
 
     legacy_path = "/var/log/mycroft"
 
-    if 'log_dir' not in config:
-        config["log_dir"] = f"{xdg_state_home()}/{get_xdg_base()}"
+    if 'logs' not in config:
+        config["logs"] = []
+    if 'path' not in config["logs"]:
+        config["logs"]["path"] = f"{xdg_state_home()}/{get_xdg_base()}"
 
-    log_dir = os.path.expanduser(config['log_dir'])
+    log_dir = os.path.expanduser(config["logs"]["path"])
     for f in os.listdir(log_dir):
         if not f.endswith(".log"):
             continue


### PR DESCRIPTION
The cli client is using the wrong config option to infer the log path.

From ovos-utils, it's using logs.path :
https://github.com/OpenVoiceOS/ovos-utils/blob/c9b1b560dab02d13a77bd9c1f3ad788e65fb9c13/ovos_utils/log.py#L53

This PR fixes this problem.